### PR TITLE
Add the day to the meeting time description

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See our full charter here: https://github.com/cncf/toc/blob/master/sigs/app-deli
 
 ## Meetings
 
-We have meetings every 2nd and 4th week of the month at 8:00 a.m. PST
+We have meetings every 2nd and 4th Wednesday of the month at 8:00 a.m. PST.
 
 + Agenda and Notes: https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit# 
 + Zoom Meeting: https://zoom.us/j/727678301


### PR DESCRIPTION
The actual day is missing in the meeting time description.