### PR TITLE
Update the README.md to reflect the proper zoom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Alois Reitbauer, Bryan Liles and Lei Zhang.
 We have meetings every 1st and 3rd Wednesday of the month at 8:00 a.m. PST.
 
 + Agenda and Notes: https://docs.google.com/document/d/1OykvqvhSG4AxEdmDMXilrupsX2n1qCSJUWwTc3I7AOs/edit# 
-+ Zoom Meeting: https://zoom.us/j/727678301
++ Zoom Meeting: https://zoom.us/j/7276783015 


### PR DESCRIPTION
The zoom link in the README is incorrect, probably due to the change in the meeting schedule. This updates the README.md to reflect the correct zoom link. 

Signed-off-by: Jeremy Rickard <jeremy.rickard@microsoft.com>