### PR TITLE
Operator WG Charter / New Chairs

### DIFF
--- a/operator-wg/README.md
+++ b/operator-wg/README.md
@@ -7,7 +7,7 @@ every other week on wednesday ([Zoom Meeting](https://zoom.us/my/cncfsigappdeliv
 * 6 PM Central European Time
 
 #### Links
-* [Charter(Draft)](https://docs.google.com/document/d/1DqHnj8O9DoU1ev9RvEdpStFUQvH-Iz6OYako6bQn9rM)
+* [Charter](./charter.md)
 * [Agenda and Meeting Notes](https://docs.google.com/document/d/17pjT2g35yUMaby0cPJnFfHRlhlFzFruDxmJKRmj_BLU)
 
 #### Documents

--- a/operator-wg/charter.md
+++ b/operator-wg/charter.md
@@ -1,0 +1,88 @@
+# Operator Working Group Charter
+
+## Interested Parties
+* Gerred Dillon (D2iQ)
+* Michael Hrivnak (Red Hat)
+* Matt Farina (Samsung SDS)
+* Aaron Meza (VMware)
+* Grant Miller (Replicated)
+* Chris Hein (Apple)
+* Soheil Eizadi (Infoblox)
+* Evan Cordell (Red Hat)
+* Feynman Zhou (KubeSphere)
+* Devdatta Kulkarni (CloudARK)
+* Michael Hausenblas (Amazon Web Services)
+* Omer Kahani (Riskified)
+* Nicolas Trangez (Scality)
+* Felipe Musse (SAP)
+* Vijay Kodam (Nokia)
+* Ran Xu (LINE Corp)
+* Waldemar Quevedo (NATS.io)
+* Chris Short (Red Hat)
+* Hongchao Deng (Alibaba)
+* Matt Jarvis ( D2iQ )
+* Kaiwalya Joshi (D2iQ)
+* Jay Pipes (AWS)
+* Cole Kennedy (BoxBoat)
+* Scott Nichols (VMware)
+* Ken Sipe (D2iQ)
+* Jed Record (Lenovo)
+* Kevin Fox (PNNL)
+* Guang Ya Liu (IBM)
+* Zach Taylor (IBM)
+* Ryan Bezdicek (Cray)
+* Jeremy Rickard (VMware)
+* Carlos Santana (IBM)
+* David Zager (Red Hat)
+* Joe Lanford (Red Hat)
+* Nick Schambureck (IBM)
+* Marc O’Brien (Red Hat)
+* Marc Campbell (Replicated)
+* Prakash Rudraraju (Salesforce)
+* Max Körbächer (Storm Reply)
+* Gigi Sayfan (Stealth startup)
+
+## Chairs/Sponsors
+* Omer Kahani (@OmerKahani)
+* Jennifer Strejevich (@Jenniferstrej)
+* Thomas Schuetz (@thschue)
+
+
+## Goals
+* Assemble and consolidate available best practices how to write operators e.g. CRDs, APIs, ….
+* Patterns and use cases how to use operators
+* Enable a forum for projects developing operators
+* Coordination work amongst participants/projects in the operator ecosystem.
+* Guidance around interoperability, configuration, management, and consumption of operators
+* Operator definition and maturity/capability model
+* Operator Security
+* Custom Resource discovery, use, auditability
+* Upgrade/Rollback best practices for controllers and CRDs
+* Data sharing between operands/operators, like some configMap, secrets etc
+* Identify requirements with other projects and engage with the right projects. Discover operator needs to present in other sigs
+
+## First Goal:
+* Create A Whitepaper (Initially Definition of an Operator)
+
+## Non-Goals
+* Writing SDKs for building operators
+* Recommendation of individual operator projects or tools
+* Non-Kubernetes Operators (at this time)
+* Creation of any new software projects
+
+## Potential Future Scope
+* Airgapped Operators
+* Meta Operator/Umbrella Operator
+* Operand Lifecycle Management
+
+## Working Group Meetings
+every other week on wednesday (Zoom Meeting)
+
+* 9 AM US Pacific Standard Time
+* 12 AM US Eastern Standard Time
+* 6 PM Central European Time
+
+
+
+ 
+


### PR DESCRIPTION
This PR includes the last version of the Operator WG charter and the new chairs are added. 