### PR TITLE
Mention Kopf for Kubernetes operator frameworks

### DIFF
--- a/operator-wg/whitepaper/05_Frameworks.md
+++ b/operator-wg/whitepaper/05_Frameworks.md
@@ -5,6 +5,8 @@
 
 [Framework_1](051_Framework_1.md) | Not even created | |
 
+[Kopf](https://github.com/nolar/kopf/) — a framework to make Kubernetes operators in Python.
+
 ## Operator Frameworks for Non-Kubernetes Platforms
 **(Current) Issue: https://github.com/cncf/sig-app-delivery/issues/41**
 


### PR DESCRIPTION
I'm not sure what is the supposed format here and would appreciate some guidance: is it a table (just not formatted)? Or is it a list? How long a description should be? Should every framework have its own page, as the Framework_1 & Framework_2 links hint? What are possible statuses of the frameworks besides "Not even created"?

Issue: #40 