### PR TITLE
[Operator-WG] Issue #34 - White paper Introduction section

### DIFF
--- a/operator-wg/whitepaper/01_Introduction.md
+++ b/operator-wg/whitepaper/01_Introduction.md
@@ -1,4 +1,4 @@
-**Status**: WIP | **Maintainer** : N/A | 
+**Status**: WIP | **Maintainer** : Jennifer Strejevitch | 
 
 ## Executive Summary
 **(Current) Issue: https://github.com/cncf/sig-app-delivery/issues/35**
@@ -11,6 +11,14 @@ An operator allows for automation of common processes as well as reactive applic
 
 ## Introduction
 **(Current) Issue: https://github.com/cncf/sig-app-delivery/issues/34**
+
+This white paper defines Operators in a wider context than Kubernetes. It describes their characteristics and components, gives an overview of common patterns currently in use and explains how they differ from Kubernetes controllers.
+
+It also dives deep into their capabilities such as backup, recovery and automatic configuration tuning, gives insight into frameworks currently in use, lifecycle management, security risks and use cases.
+
+This paper includes best practices including observability and security, technical implementation and CNCF maintained code samples.
+
+It closes with related work, what additional value they can bring beyond this white paper and the next steps for Operators.
 
 ### The goal of this document
 The goal of this document is to provide a definition of operators for cloud-native applications in the context of Kubernetes and other container orchestrators.


### PR DESCRIPTION
Introduction section of the Operator white paper. 

Format inspired by the first section of https://github.com/cncf/wg-serverless/tree/master/whitepapers/serverless-overview#cncf-serverless-whitepaper-v10