### PR TITLE
contributing guidelines

### DIFF
--- a/operator-wg/CONTRIBUTING.md
+++ b/operator-wg/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to the Operator White Paper
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+## How do I get involved
+
+- Join us in Slack [#sig-app-delivery-operator-wg](https://cloud-native.slack.com/archives/C01GTMYJLKS).
+- Our working group [meetings](https://github.com/cncf/sig-app-delivery/tree/master/operator-wg#meetings).
+
+## How to contribute
+
+Please take a look at the [Project board](https://github.com/cncf/sig-app-delivery/projects/1) and:
+
+1. Pick an issue/white paper section that you would like to contribute.
+2. Reach out to us on slack and we will assign the issue to you/update progress.
+3. Fork/Make a Pull Request.
+4. If it’s a major change, that will go through a one week cycle for review.
+5. Once there are at least two approvals by the WG chairs and the time is up, your change will be merged to https://github.com/cncf/sig-app-delivery/tree/master/operator-wg/whitepaper
+
+If you have any suggestions or questions, please let us know here or attend any of our bi-weekly meetings. We have the objective to find assignees for the remaining issues by the next WG meeting. Your collaboration will be very welcome. Thank you!

--- a/operator-wg/README.md
+++ b/operator-wg/README.md
@@ -5,7 +5,7 @@ Create A Whitepaper (Initially Definition of an Operator)
 
 ### How to contribute
 1. Join us in Slack [#sig-app-delivery-operator-wg](https://cloud-native.slack.com/archives/C01GTMYJLKS)
-2. Read the [Operator Whitepaper](https://docs.google.com/document/d/1daXHyR2yG5ArjO1PO83v4a0fmLCLo2kYNT3TwGZksng)
+2. Read the [Operator Whitepaper](./whitepaper/README.md)
 3. Grab a ticket and write content - we have a [project with all the tickets](https://github.com/cncf/sig-app-delivery/projects/1)
 4. Open a new ticket for things that are missing
 

--- a/operator-wg/README.md
+++ b/operator-wg/README.md
@@ -9,6 +9,8 @@ Create A Whitepaper (Initially Definition of an Operator)
 3. Grab a ticket and write content - we have a [project with all the tickets](https://github.com/cncf/sig-app-delivery/projects/1)
 4. Open a new ticket for things that are missing
 
+For more details, see our [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ### Meetings
 Every other week on Wednesday ([Zoom Meeting](https://zoom.us/my/cncfsigappdelivery?pwd=R0RJMkRzQ1ZjcmE0WERGcTJTOEVyUT09))
 * 9 AM US Pacific Standard Time


### PR DESCRIPTION
1. more detailed contributing section - Inspired by https://docs.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors

2. removed deprecated google doc from White paper link on README